### PR TITLE
chore: add env option for frontend and backend base urls

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -12,7 +12,7 @@ const port = 3001;
 app.use(express.json());
 app.use(cookieParser());
 app.use(cors({
-  origin: 'http://localhost:3000',
+  origin: process.env.FRONTEND_BASE_URL || 'http://localhost:3000',
   credentials: true,
 }));
 

--- a/packages/frontend/src/api/index.ts
+++ b/packages/frontend/src/api/index.ts
@@ -3,7 +3,7 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 // Define a service using a base URL and expected endpoints
 const trofosApiSlice = createApi({
   reducerPath: 'trofosApi',
-  baseQuery: fetchBaseQuery({ baseUrl: 'http://localhost:3001' }),
+  baseQuery: fetchBaseQuery({ baseUrl: process.env.REACT_APP_BACKEND_BASE_URL || 'http://localhost:3001' }),
   tagTypes: ['Project', 'UserInfo', 'Course', 'Backlog'],
   endpoints: () => ({}),
 });


### PR DESCRIPTION
Add option for using env variables for base urls. This is to help in deployment as urls for the backend and frontend will change between development and deployment sites.

### Changes
- Add env option for frontend base url (`FRONTEND_BASE_URL`)
- Add env option for backend base url (`REACT_APP_BACKEND_BASE_URL`)