### PR TITLE
ci: add deployment pipeline and notification for ci failure

### DIFF
--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -47,3 +47,11 @@ jobs:
       - name: Clean up container
         if: always()
         run: npm run cleanup:ci
+      - name: Send notification on failure
+        if: failure()
+        run: |
+          message="[CI Failed]
+          Commit: ${{ github.sha }}
+          View full log here: https://github.com/Project-Trofos/trofos/actions/runs/${{ github.run_id }}
+          "
+          curl --data-urlencode "text=${message}" ${{ secrets.NOTIFICATION_API }}

--- a/.github/workflows/staging-ci.yaml
+++ b/.github/workflows/staging-ci.yaml
@@ -39,3 +39,26 @@ jobs:
       - name: Clean up containers
         if: always()
         run: npm run cleanup:ci
+      - name: Send notification on failure
+        if: failure()
+        run: |
+          message="[CI Failed]
+          Commit: ${{ github.sha }}
+          View full log here: https://github.com/Project-Trofos/trofos/actions/runs/${{ github.run_id }}
+          "
+          curl --data-urlencode "text=${message}" ${{ secrets.NOTIFICATION_API }}
+  deploy:
+    needs: test-with-docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send deployment request to webhook
+        run: curl ${{ secrets.DEPLOYMENT_WEBHOOK_API }}
+      - name: Send notification on failure
+        if: failure()
+        run: |
+          message="[Build Failed]
+          Commit: ${{ github.sha }}
+          View full log here: https://github.com/Project-Trofos/trofos/actions/runs/${{ github.run_id }}
+          "
+          curl --data-urlencode "text=${message}" ${{ secrets.NOTIFICATION_API }}
+      


### PR DESCRIPTION
Github Actions only notifies the user that triggered the workflow via email when the CI failed. To broadcast this alert to more than 1 user, we will need to use an external service. A telegram channel has been created which the Github Actions will send the notifications to. The notification service can be easily updated by changing the secret `NOTIFICATION_API`

### Changes
- Add deployment job to send webhook to VM
- Add notification step on any failure