### PR TITLE
ci: temporary remove e2e test from CI

### DIFF
--- a/.github/workflows/pull-request-ci.yaml
+++ b/.github/workflows/pull-request-ci.yaml
@@ -36,14 +36,15 @@ jobs:
           npm run prisma-migrate-ci
       - name: Run test
         run: npm run test
-      - name: Start backend and frontend
-        run: npm start &
-      - name: Wait for backend and frontend to start
-        run: wait-on --timeout 120000 http://localhost:3000 http://localhost:3001
-      - name: Run e2e test
-        run: |-
-          cd packages/backend
-          npm run test-e2e
+      # e2e test currently removed from CI as it is unstable
+      # - name: Start backend and frontend
+      #   run: npm start &
+      # - name: Wait for backend and frontend to start
+      #   run: wait-on --timeout 120000 http://localhost:3000 http://localhost:3001
+      # - name: Run e2e test
+      #   run: |-
+      #     cd packages/backend
+      #     npm run test-e2e
       - name: Clean up container
         if: always()
         run: npm run cleanup:ci

--- a/.github/workflows/staging-ci.yaml
+++ b/.github/workflows/staging-ci.yaml
@@ -28,14 +28,15 @@ jobs:
         run: docker compose -f docker-compose-ci.yml build backend
       - name: Build and test frontend
         run: docker compose -f docker-compose-ci.yml build frontend
-      - name: Run backend and frontend containers
-        run: |- 
-          docker run --rm --network host --name backend -d trofos_backend
-          docker run --rm --network host --name frontend -d trofos_frontend
-      - name: Wait for backend and frontend containers to start
-        run: wait-on --timeout 120000 http://localhost:3000 http://localhost:3001
-      - name: Run e2e test
-        run: docker exec backend npm run test-e2e
+      # e2e test currently removed from CI as it is unstable
+      # - name: Run backend and frontend containers
+      #   run: |- 
+      #     docker run --rm --network host --name backend -d trofos_backend
+      #     docker run --rm --network host --name frontend -d trofos_frontend
+      # - name: Wait for backend and frontend containers to start
+      #   run: wait-on --timeout 120000 http://localhost:3000 http://localhost:3001
+      # - name: Run e2e test
+      #   run: docker exec backend npm run test-e2e
       - name: Clean up containers
         if: always()
         run: npm run cleanup:ci


### PR DESCRIPTION
### Changes
- Commented out e2e test from CI as it is currently unstable. Will reimplement e2e after the issues have been resolved.