### PR TITLE
fix: search redirect for course

### DIFF
--- a/packages/frontend/src/components/search/GlobalSearch.tsx
+++ b/packages/frontend/src/components/search/GlobalSearch.tsx
@@ -25,7 +25,7 @@ export default function GlobalSearch(): JSX.Element {
     // Filter courses by search string
     const filteredCourses = courses
       .filter((c) => c.cname.toLowerCase().includes(searchString.toLowerCase()))
-      .map((c) => renderItem(c.cname, c.id, 'course'));
+      .map((c) => renderItem(c.cname, `${c.id}/${c.year}/${c.sem}`, 'course'));
     if (filteredCourses.length === 0) {
       return undefined;
     }


### PR DESCRIPTION
This PR fixes a small bug in search redirect, because course is using `id/year/sem` for frontend redirect.

After the primary key of course is changed, I will change this back to using `id`.