### PR TITLE
fix: minor css styling issue

### DIFF
--- a/packages/frontend/src/components/cards/VisualizationCard.css
+++ b/packages/frontend/src/components/cards/VisualizationCard.css
@@ -1,9 +1,13 @@
-/* TODO (Luoyi): The arrow in select is misaligned for some reason */
-.ant-select-arrow {
-  transform: translateY(-12px);
-}
-
 .visualization-card .visualization-card-header {
   display: flex;
   justify-content: space-between;
+}
+
+.visualization-card .visualization-card-header .visualization-card-header-text {
+  margin-bottom: 30px;
+}
+
+.visualization-card .visualization-card-header .visualization-card-selector {
+  width: 140px;
+  height: 32px;
 }

--- a/packages/frontend/src/components/cards/VisualizationCard.tsx
+++ b/packages/frontend/src/components/cards/VisualizationCard.tsx
@@ -15,9 +15,9 @@ export default function VisualizationCard({ projectId }: { projectId: number | u
   return (
     <Card className="visualization-card">
       <div className="visualization-card-header">
-        <Subheading style={{ marginBottom: '30px' }}>Burn Down Chart</Subheading>
+        <Subheading className="visualization-card-header-text">Burn Down Chart</Subheading>
         <Select
-          style={{ width: '140px' }}
+          className="visualization-card-selector"
           placeholder="Select a sprint"
           options={
             sprintsData?.sprints.map((s) => {

--- a/packages/frontend/src/pages/ScrumBoard.css
+++ b/packages/frontend/src/pages/ScrumBoard.css
@@ -1,6 +1,8 @@
 .scrum-board-drag-drop-context {
   background: #fff;
+  min-height: 100%;
   overflow-x: auto;
+  padding-bottom: 40px;
 }
 
 .scrum-board-status-container {


### PR DESCRIPTION
There are some minor styling issues/bugs in the project overview and scrum board page. This PR aims to resolve these.

### Changes
- Shifted `VisualizationCard.tsx`'s inline css to `VisualizationCard.css` file
- Set fixed height on visualization card header to resolve misaligned arrow button on selector
- Added minimum height and padding to scrum board