### PR TITLE
fix(frontend): socket io should connect to correct backend path

### DIFF
--- a/packages/frontend/src/api/socket/socket.ts
+++ b/packages/frontend/src/api/socket/socket.ts
@@ -15,8 +15,9 @@ type ClientToServerEvents = {
 };
 
 const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io(
-  process.env.REACT_APP_BACKEND_BASE_URL || 'http://localhost:3001',
+  process.env.REACT_APP_SOCKET_IO_BASE_URL || 'http://localhost:3001',
   {
+    path: process.env.REACT_APP_SOCKET_IO_PATH,
     withCredentials: true,
   },
 );


### PR DESCRIPTION
As discussed with @jonahtanjz, socket io should connect to the correct backend path.
![image](https://user-images.githubusercontent.com/51979232/216533408-ac177fe0-b42a-4126-aff0-0a8494c94178.png)

Two environment variables should be added to the frontend:
1. `REACT_APP_SOCKET_IO_BASE_URL`
2. `REACT_APP_SOCKET_IO_PATH`