### PR TITLE
style: user table should have more rows

### DIFF
--- a/packages/frontend/src/components/tables/UserTable.test.tsx
+++ b/packages/frontend/src/components/tables/UserTable.test.tsx
@@ -1,17 +1,15 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { Provider } from 'react-redux';
 
 import { UserData } from '../../api/types';
 import UserTable from './UserTable';
-import store from '../../app/store';
 
 describe('test UserTable', () => {
   const mockUsers: UserData[] = [
     {
       user: {
         user_email: 'email',
-        user_display_name: "Test User",
+        user_display_name: 'Test User',
         user_id: 999,
         courseRoles: [
           {

--- a/packages/frontend/src/components/tables/UserTable.tsx
+++ b/packages/frontend/src/components/tables/UserTable.tsx
@@ -37,14 +37,7 @@ export default function UserTable({
           <Subheading>{heading ?? 'People'}</Subheading>
           {control}
         </Space>
-        <Table
-          dataSource={users}
-          rowKey={(user) => user.user.user_id}
-          loading={isLoading}
-          bordered
-          size="small"
-          pagination={{ pageSize: 5 }}
-        >
+        <Table dataSource={users} rowKey={(user) => user.user.user_id} loading={isLoading} bordered size="small">
           <Table.Column
             width={150}
             title="ID"
@@ -61,10 +54,7 @@ export default function UserTable({
             dataIndex={['user', 'user_email']}
             sorter={(a: UserData, b: UserData) => a.user.user_email.localeCompare(b.user.user_email)}
           />
-          <Table.Column
-            title="Display Name"
-            dataIndex={['user', 'user_display_name']}
-          />
+          <Table.Column title="Display Name" dataIndex={['user', 'user_display_name']} />
           <Table.Column
             width={150}
             title="Action"


### PR DESCRIPTION
Use the default number (10) of rows for user table, so more users can be shown on one page.