### PR TITLE
fix: scrumboard should scroll properly

### DIFF
--- a/packages/frontend/src/pages/Project.css
+++ b/packages/frontend/src/pages/Project.css
@@ -1,6 +1,7 @@
 .overflow-scroll-container {
   height: 0;
   flex-grow: 1;
+  background-color: white;
   overflow: auto;
 }
 

--- a/packages/frontend/src/pages/ScrumBoard.css
+++ b/packages/frontend/src/pages/ScrumBoard.css
@@ -1,7 +1,5 @@
 .scrum-board-drag-drop-context {
   background: #fff;
-  min-height: 100%;
-  overflow-x: auto;
   padding-bottom: 40px;
 }
 


### PR DESCRIPTION
Apparently react beautiful dnd automatically detec scroll containers based on `overflow: scroll` css property, and it doesn't support nested scroll containers. Therefore, I just remove the inner container which has a `overflow` property and it works now.

![image](https://user-images.githubusercontent.com/51979232/223318703-be450a5c-705d-4493-8bdd-a399630e4747.png)
