### PR TITLE
fix: fix add user bug such that user's role is updated

### DIFF
--- a/packages/frontend/src/api/course.ts
+++ b/packages/frontend/src/api/course.ts
@@ -88,7 +88,7 @@ const extendedApi = trofosApiSlice.injectEndpoints({
         },
         credentials: 'include',
       }),
-      invalidatesTags: (result, error, { id }) => [{ type: 'Course', id }],
+      invalidatesTags: (result, error, { id }) => [{ type: 'Course', id }, { type: 'CourseRoles', id }],
     }),
 
     // Invalidate course

--- a/packages/frontend/src/api/project.ts
+++ b/packages/frontend/src/api/project.ts
@@ -82,7 +82,7 @@ const extendedApi = trofosApiSlice.injectEndpoints({
         },
         credentials: 'include',
       }),
-      invalidatesTags: (result, error, arg) => [{ type: 'Project', id: arg.id }, 'Course'],
+      invalidatesTags: (result, error, arg) => [{ type: 'Project', id: arg.id }, 'Course', { type: 'ProjectRoles', id : arg.id}],
     }),
 
     // Removing a user in a project will invalidate that project


### PR DESCRIPTION
## Context

This PR aims to fix a bug when adding a user to a course/project. Currently, when a user is added, their role for the course/project remains blank in the table until the page is manually updated. This should happen automatically. For an illustration of the issue, see the attached issue below. 

Closes #118 

**Bug Fixes**:

Bug was fixed by adding an additional invalidation tag in `addProjectUser` and `addCourseUser` that invalidates `ProjectRoles` and `CourseRoles` respectively.
