### PR TITLE
Fix: caching issue

### DIFF
--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -6,11 +6,9 @@ services:
       dockerfile: Dockerfile.production
       target: prod
     ports:
-      - '3000:3000'
+      - '80:80'
     container_name: trofos-frontend-production
     restart: always
-    links:
-      - backend
   backend:
     build:
       context: ./packages/backend
@@ -20,8 +18,10 @@ services:
       - '3001:3001'
     container_name: trofos-backend-production
     restart: always
-    links:
+    depends_on:
       - postgres
+    environment:
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres/trofos?schema=public
   postgres:
     image: postgres:14.1-alpine
     restart: always

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -15,7 +15,7 @@ import settingsRouter from './routes/settings.route';
 const app = express();
 
 export const port = 3001;
-export const frontendUrl = process.env.FRONTEND_BASE_URL || 'http://localhost:3000';
+export const frontendUrl = process.env.FRONTEND_BASE_URL || 'http://localhost';
 
 export const corsOptions = {
   origin: frontendUrl,

--- a/packages/frontend/Dockerfile.production
+++ b/packages/frontend/Dockerfile.production
@@ -1,31 +1,38 @@
 # Base image
 FROM node:16.17.0-alpine as base
 
-# Expose port to access server
-EXPOSE 3000
-
 # Make folder to put our files in
 RUN mkdir -p /usr/src/app/frontend
 
 # Set working directory so that all subsequent command runs in this folder
 WORKDIR /usr/src/app/frontend
 
-# Copy package json and install dependencies
-COPY package*.json ./
+COPY . .
+
+RUN npm ci
 
 # Test stage for CI
 FROM base as test
-RUN npm ci
-# Copy our app
-COPY . .
 # Run unit test
 RUN npm test
+
 ENTRYPOINT ["npm", "start"]
 
+# Build stage 
+FROM base as build
+# Build the app
+RUN npm run build
+
 # Production stage
-FROM base as prod
-RUN npm ci
-# Copy our app
-COPY . .
+FROM nginx:alpine as prod
+
+EXPOSE 80
+
+WORKDIR /usr/share/nginx/html
+
+RUN rm -rf ./*
+
+# Copy built app
+COPY --from=build /usr/src/app/frontend/build .
 # Command to run our app
-ENTRYPOINT ["npm", "run", "start-dev"]
+ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -57,10 +57,10 @@
   },
   "eslintConfig": {
     "extends": [
-      "../../.eslintrc.json",
       "react-app",
       "react-app/jest"
-    ]
+    ],
+    "root": false
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
* change dockerfile for production to build the front end, then deploy using nginx rather than use webpack's dev server
* change eslint configuration to simply inherit merge with parent directory eslint
* change port for front end to 80

Will need to modify the proxy on the servers to stop redirecting `/` to port `3000` as we are now using an nginx docker

- [ ] Test in staging 