### PR TITLE
Integrate today's standup board with active scrum board page

### DIFF
--- a/packages/backend/src/routes/project.route.ts
+++ b/packages/backend/src/routes/project.route.ts
@@ -6,8 +6,11 @@ import { hasAuth, hasAuthForProject } from '../middleware/auth.middleware';
 import projectPolicy from '../policies/project.policy';
 import feedbackPolicy from '../policies/feedback.policy';
 import feedback from '../controllers/feedback';
+import standupRouter from './standup.route';
 
 const router = express.Router();
+
+router.use('/:projectId/standup', standupRouter);
 
 // Get all projects
 router.get('/', hasAuth(Action.read_project, projectPolicy.POLICY_NAME), project.getAll);

--- a/packages/backend/src/routes/standup.route.ts
+++ b/packages/backend/src/routes/standup.route.ts
@@ -4,7 +4,8 @@ import standUp from '../controllers/standup';
 import { hasAuthForProject } from '../middleware/auth.middleware';
 import projectPolicy from '../policies/project.policy';
 
-const router = express.Router();
+// Get projectId from parent route
+const router = express.Router({ mergeParams: true});
 
 // Create a stand up
 router.post(
@@ -14,7 +15,7 @@ router.post(
 );
 
 // Get all stand ups of a project
-router.get('/:projectId', hasAuthForProject(Action.read_project, projectPolicy.POLICY_NAME), standUp.getStandUpHeaders);
+router.get('/', hasAuthForProject(Action.read_project, projectPolicy.POLICY_NAME), standUp.getStandUpHeaders);
 
 // Update stand up
 router.put(
@@ -31,13 +32,14 @@ router.delete(
 );
 
 router.post('/createNote', hasAuthForProject(Action.update_project, projectPolicy.POLICY_NAME), standUp.addStandUpNote);
+
 router.get(
   '/getNotes/:standUpId',
   hasAuthForProject(Action.update_project, projectPolicy.POLICY_NAME),
   standUp.getStandUp,
 );
 router.get(
-  '/getAllNotes/:projectId',
+  '/getAllNotes',
   hasAuthForProject(Action.update_project, projectPolicy.POLICY_NAME),
   standUp.getStandUps,
 );

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -4,7 +4,6 @@ import cookieParser from 'cookie-parser';
 import accountRouter from './routes/account.route';
 import courseRouter from './routes/course.route';
 import projectRouter from './routes/project.route';
-import standUpRouter from './routes/standup.route';
 import backlogRouter from './routes/backlog.route';
 import userRouter from './routes/user.route';
 import sprintRouter from './routes/sprint.route';
@@ -45,8 +44,7 @@ router.use('/course', courseRouter);
 // Routes for project
 router.use('/project', projectRouter);
 
-// Routes for standUp
-router.use('/standUp', standUpRouter);
+// Routes for standUp are in projectRouter
 
 // Routes for epic
 router.use('/epic', epicRouter);

--- a/packages/frontend/src/api/socket/standUpHooks.ts
+++ b/packages/frontend/src/api/socket/standUpHooks.ts
@@ -12,15 +12,15 @@ import { UpdateType } from './socket';
 import { emitUpdateEvent } from './useSocket';
 
 export const useAddStandUpNoteMutation = attachFunctionToRtkHookHOF(rtkUseAddStandUpNoteMutation, (mutArgs) => {
-  emitUpdateEvent(`${UpdateType.STAND_UP_NOTES}/${mutArgs.stand_up_id}`);
+  emitUpdateEvent(`${UpdateType.STAND_UP_NOTES}/${mutArgs.standUpNote.stand_up_id}`);
 });
 
 export const useUpdateStandUpNoteMutation = attachFunctionToRtkHookHOF(rtkUseUpdateStandUpNoteMutation, (mutArgs) => {
-  emitUpdateEvent(`${UpdateType.STAND_UP_NOTES}/${mutArgs.stand_up_id}`);
+  emitUpdateEvent(`${UpdateType.STAND_UP_NOTES}/${mutArgs.standUpNoteToUpdate.stand_up_id}`);
 });
 
 export const useDeleteStandUpNoteMutation = attachFunctionToRtkHookHOF(rtkUseDeleteStandUpNoteMutation, (mutArgs) => {
-  emitUpdateEvent(`${UpdateType.STAND_UP_NOTES}/${mutArgs.stand_up_id}`);
+  emitUpdateEvent(`${UpdateType.STAND_UP_NOTES}/${mutArgs.id.stand_up_id}`);
 });
 
 export const useAddStandUpMutation = attachFunctionToRtkHookHOF(rtkUseAddStandUpMutation, (mutArgs) => {

--- a/packages/frontend/src/api/standup.ts
+++ b/packages/frontend/src/api/standup.ts
@@ -23,14 +23,14 @@ export const extendedApi = trofosApiSlice.injectEndpoints({
   endpoints: (builder) => ({
     getStandUpHeadersByProjectId: builder.query<StandUpHeader[], number>({
       query: (project_id) => ({
-        url: `standUp/${project_id}`,
+        url: `project/${project_id}/standUp/`,
         credentials: 'include',
       }),
       providesTags: ['StandUpHeader'],
     }),
     addStandUp: builder.mutation<StandUpHeader, Omit<StandUpHeader, 'id'>>({
       query: (standUp) => ({
-        url: 'standUp/createStandUp/',
+        url: `project/${standUp.project_id}/standUp/createStandUp/`,
         method: 'POST',
         body: standUp,
         credentials: 'include',
@@ -39,61 +39,61 @@ export const extendedApi = trofosApiSlice.injectEndpoints({
     }),
     updateStandUp: builder.mutation<StandUpHeader, StandUpHeader>({
       query: (standUpToUpdate) => ({
-        url: 'standUp/updateStandUp/',
+        url: `project/${standUpToUpdate.project_id}/standUp/updateStandUp/`,
         method: 'PUT',
         body: standUpToUpdate,
         credentials: 'include',
       }),
       invalidatesTags: ['StandUpHeader'],
     }),
-    deleteStandUp: builder.mutation<void, Pick<StandUp, 'id' | 'project_id'>>({
-      query: ({ id }) => ({
-        url: `standUp/deleteStandUp/${id}`,
+    deleteStandUp: builder.mutation<void, StandUp>({
+      query: (standUp) => ({
+        url: `project/${standUp.project_id}/standUp/deleteStandUp/${standUp.id}`,
         method: 'DELETE',
         credentials: 'include',
       }),
       invalidatesTags: (_result, _error, arg) => [{ type: 'StandUp', id: arg.id }, 'StandUpHeader'],
     }),
-    addStandUpNote: builder.mutation<StandUpNote, StandUpNoteFormFields>({
-      query: (standUpNote) => ({
-        url: 'standUp/createNote',
+    addStandUpNote: builder.mutation<StandUpNote, {project_id: number, standUpNote: StandUpNoteFormFields}>({
+      query: ({project_id, standUpNote}) => ({
+        url: `project/${project_id}/standUp/createNote`,
         method: 'POST',
         body: standUpNote,
         credentials: 'include',
       }),
-      invalidatesTags: (_result, _error, arg) => [{ type: 'StandUp', id: arg.stand_up_id }],
+      invalidatesTags: (_result, _error, arg) => [{ type: 'StandUp', id: arg.standUpNote.stand_up_id }],
     }),
     getStandUps: builder.query<StandUp[], Pick<StandUp, 'project_id'>>({
       query: ({ project_id }) => ({
-        url: `standUp/getAllNotes/${project_id}`,
+        url: `project/${project_id}/standUp/getAllNotes`,
         credentials: 'include',
       }),
       providesTags: (result, _error, _arg) =>
         result ? [...result.map(({ id }) => ({ type: 'StandUp' as const, id })), 'StandUp'] : ['StandUp'],
     }),
-    getStandUp: builder.query<StandUp, Pick<StandUp, 'id'>>({
-      query: ({ id }) => ({
-        url: `standUp/getNotes/${id}`,
+    getStandUp: builder.query<StandUp, {project_id: number, id: Pick<StandUp, 'id'>}>({
+      query: ({project_id, id}) => ({
+        url: `project/${project_id}/standUp/getNotes/${id.id}`,
         credentials: 'include',
       }),
-      providesTags: (_result, _error, arg) => [{ type: 'StandUp', id: arg.id }],
+      providesTags: (_result, _error, arg) => [{ type: 'StandUp', id: arg.id.id }],
     }),
-    updateStandUpNote: builder.mutation<StandUpNote, StandUpNote>({
-      query: (standUpNoteToUpdate) => ({
-        url: 'standUp/updateStandUpNote/',
+    updateStandUpNote: builder.mutation<StandUpNote, {project_id: number, standUpNoteToUpdate: StandUpNote}>({
+      query: ({project_id, standUpNoteToUpdate}) => ({
+        url: `project/${project_id}/standUp/updateStandUpNote/`,
         method: 'PUT',
         body: standUpNoteToUpdate,
         credentials: 'include',
       }),
-      invalidatesTags: (_result, _error, arg) => [{ type: 'StandUp', id: arg.stand_up_id }],
+      invalidatesTags: (_result, _error, arg) => [{ type: 'StandUp', id: arg.standUpNoteToUpdate.stand_up_id }],
     }),
-    deleteStandUpNote: builder.mutation<void, Pick<StandUpNote, 'id' | 'stand_up_id'>>({
-      query: ({ id }) => ({
-        url: `standUp/deleteStandUpNote/${id}`,
+    deleteStandUpNote: builder.mutation<void, {project_id: number, id: Pick<StandUpNote, 'id' | 'stand_up_id'>}>({
+      query: ({ project_id, id }) => ({
+        url: `project/${project_id}/standUp/deleteStandUpNote/${id.id}`,
         method: 'DELETE',
         credentials: 'include',
       }),
-      invalidatesTags: (_result, _error, arg) => [{ type: 'StandUp', id: arg.stand_up_id }],
+      invalidatesTags: (_result, _error, arg) => [{ type: 'StandUp', id: arg.id.stand_up_id }],
     }),
   }),
   overrideExisting: false,

--- a/packages/frontend/src/components/board/ScrumBoard.tsx
+++ b/packages/frontend/src/components/board/ScrumBoard.tsx
@@ -10,12 +10,17 @@ import StrictModeDroppable from '../dnd/StrictModeDroppable';
 import { Sprint } from '../../api/sprint';
 
 import './ScrumBoard.css';
+import { StandUp } from '../../api/standup';
 
 const { Title } = Typography;
 
-type ScrumBoardProps = { projectId: number; sprint?: Sprint };
+type ScrumBoardProps = {
+  projectId: number;
+  sprint?: Sprint
+  standUp?: StandUp;
+};
 
-export default function ScrumBoard({ projectId, sprint }: ScrumBoardProps): JSX.Element {
+export default function ScrumBoard({ projectId, sprint, standUp }: ScrumBoardProps): JSX.Element {
   const { data: backlogStatus } = useGetBacklogStatusQuery({ id: projectId });
   const { data: projectData } = useGetProjectQuery({ id: projectId });
 
@@ -118,6 +123,7 @@ export default function ScrumBoard({ projectId, sprint }: ScrumBoardProps): JSX.
                         projectKey={projectData?.pkey}
                         id={backlog.backlog_id}
                         index={index}
+                        standUp={standUp}
                       />
                     ))}
                   {provided.placeholder}

--- a/packages/frontend/src/components/board/StandUpBoard/StandUpBoard.tsx
+++ b/packages/frontend/src/components/board/StandUpBoard/StandUpBoard.tsx
@@ -55,6 +55,7 @@ export default function StandUpBoard({ standUp, readOnly }: StandUpBoardProps): 
                       .sort((a, b) => a.id - b.id)}
                     userId={user.user.user_id}
                     readOnly={readOnly}
+                    project_id={projectId}
                   />
                 );
               })}

--- a/packages/frontend/src/components/board/StandUpBoard/StandUpBoard.tsx
+++ b/packages/frontend/src/components/board/StandUpBoard/StandUpBoard.tsx
@@ -12,6 +12,12 @@ const { Title } = Typography;
 
 type StandUpBoardProps = { standUp: StandUp; readOnly?: boolean };
 
+export const COLUMN_MAPPING = {
+  DONE: 0,
+  NEXT: 1,
+  BLOCKERS: 2,
+};
+
 export default function StandUpBoard({ standUp, readOnly }: StandUpBoardProps): JSX.Element {
   const projectId = useProjectIdParam();
 

--- a/packages/frontend/src/components/board/StandUpBoard/StandUpColumn.tsx
+++ b/packages/frontend/src/components/board/StandUpBoard/StandUpColumn.tsx
@@ -13,6 +13,7 @@ type StandUpBoardColumnProps = {
   columnId: number;
   userId: number;
   readOnly?: boolean;
+  project_id: number;
 };
 
 export default function StandUpColumn({
@@ -21,6 +22,7 @@ export default function StandUpColumn({
   standUpId,
   userId,
   readOnly,
+  project_id,
 }: StandUpBoardColumnProps): JSX.Element {
   const [form] = Form.useForm();
 
@@ -30,7 +32,15 @@ export default function StandUpColumn({
     const { content } = formData;
     if (!content) return;
     try {
-      await addStandUpNote({ stand_up_id: standUpId, content, column_id: columnId, user_id: userId }).unwrap();
+      await addStandUpNote({ 
+        project_id: project_id,
+        standUpNote: {
+          stand_up_id: standUpId,
+          content,
+          column_id: columnId,
+          user_id: userId
+        }
+      }).unwrap();
     } catch (err) {
       message.error(getErrorMessage(err));
     }
@@ -42,7 +52,13 @@ export default function StandUpColumn({
     (noteId: number) => {
       return async () => {
         try {
-          await deleteStandUpNote({ stand_up_id: standUpId, id: noteId }).unwrap();
+          await deleteStandUpNote({
+            project_id: project_id,
+            id: {
+              stand_up_id: standUpId,
+              id: noteId
+            }
+          }).unwrap();
         } catch (err) {
           message.error(getErrorMessage(err));
         }

--- a/packages/frontend/src/components/cards/ScrumBoardCard.test.tsx
+++ b/packages/frontend/src/components/cards/ScrumBoardCard.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import { DragDropContext } from 'react-beautiful-dnd';
@@ -7,8 +7,36 @@ import store from '../../app/store';
 import type { Backlog } from '../../api/types';
 import { ScrumBoardCard } from './ScrumBoardCard';
 import StrictModeDroppable from '../dnd/StrictModeDroppable';
+import { StandUp } from '../../api/standup';
 
 describe('ScrumBoardCard test', () => {
+  const setup = (mockBacklog: Backlog, mockStandUp?: StandUp) => {
+    const mockProjectKey = 'TEST';
+    const mockIndex = 0;
+    const mockDroppableId = '0';
+    const { baseElement, debug } = render(
+      <Provider store={store}>
+        <BrowserRouter>
+          <DragDropContext onDragEnd={vi.fn()}>
+            <StrictModeDroppable droppableId={mockDroppableId}>
+              {(provided) => (
+                <div ref={provided.innerRef} {...provided.droppableProps}>
+                  <ScrumBoardCard
+                    backlog={mockBacklog}
+                    projectKey={mockProjectKey}
+                    id={mockIndex}
+                    index={0}
+                    standUp={mockStandUp}
+                  />
+                </div>
+              )}
+            </StrictModeDroppable>
+          </DragDropContext>
+        </BrowserRouter>
+      </Provider>,
+    );
+    return { baseElement, debug };
+  }
   const mockBacklog: Backlog = {
     backlog_id: 111,
     summary: 'A Test Summary',
@@ -32,26 +60,15 @@ describe('ScrumBoardCard test', () => {
     },
   };
 
-  const mockProjectKey = 'TEST';
-  const mockIndex = 0;
-  const mockDroppableId = '0';
-  const { baseElement } = render(
-    <Provider store={store}>
-      <BrowserRouter>
-        <DragDropContext onDragEnd={vi.fn()}>
-          <StrictModeDroppable droppableId={mockDroppableId}>
-            {(provided) => (
-              <div ref={provided.innerRef} {...provided.droppableProps}>
-                <ScrumBoardCard backlog={mockBacklog} projectKey={mockProjectKey} id={mockIndex} index={0} />
-              </div>
-            )}
-          </StrictModeDroppable>
-        </DragDropContext>
-      </BrowserRouter>
-    </Provider>,
-  );
+  const mockStandUp: StandUp = {
+    id: 1,
+    date: new Date(),
+    project_id: 903,
+    notes: [],
+  };
 
   it('renders scrum board card with correct details', () => {
+    const { baseElement } = setup(mockBacklog);
     expect(screen.getByText(mockBacklog.summary)).toBeInTheDocument();
     expect(screen.getByText(mockBacklog.type)).toBeInTheDocument();
     expect(screen.getByText(mockBacklog?.points?.toString() as string)).toBeInTheDocument();
@@ -59,4 +76,20 @@ describe('ScrumBoardCard test', () => {
     // Compare with snapshot to ensure structure remains the same
     expect(baseElement).toMatchSnapshot();
   });
+
+  it('renders scrum board card with standup options if stand up param is provided', async () => {
+    const { baseElement, debug } = setup(mockBacklog, mockStandUp);
+    expect(screen.getByText(mockBacklog.summary)).toBeInTheDocument();
+    expect(screen.getByText(mockBacklog.type)).toBeInTheDocument();
+    expect(screen.getByText(mockBacklog?.points?.toString() as string)).toBeInTheDocument();
+    const dropdownButton = screen.getByLabelText(/setting/i);
+    fireEvent.mouseOver(dropdownButton);
+    await waitFor(() => {
+      expect(screen.getByText('Mark as Done in Standup')).toBeInTheDocument();
+      expect(screen.getByText('Mark as Next in Standup')).toBeInTheDocument();
+      expect(screen.getByText('Mark as Blockers in Standup')).toBeInTheDocument();
+    });
+    // Compare with snapshot to ensure structure remains the same
+    expect(baseElement).toMatchSnapshot();
+  })
 });

--- a/packages/frontend/src/components/cards/ScrumBoardCard.tsx
+++ b/packages/frontend/src/components/cards/ScrumBoardCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Card } from 'antd';
+import { Card, Dropdown, message } from 'antd';
+import { SettingOutlined } from '@ant-design/icons';
 import { useNavigate, useParams } from 'react-router-dom';
 import { isEqual } from 'lodash';
 import { UserAvatar } from '../avatar/UserAvatar';
@@ -7,17 +8,70 @@ import type { Backlog } from '../../api/types';
 import { draggableWrapper } from '../../helpers/dragAndDrop';
 import { BACKLOG_PRIORITY_OPTIONS } from '../../helpers/constants';
 import './ScrumBoardCard.css';
+import { MenuProps } from 'antd/lib';
+import { COLUMN_MAPPING } from '../board/StandUpBoard/StandUpBoard';
+import { useAddStandUpNoteMutation } from '../../api/socket/standUpHooks';
+import { StandUp } from '../../api/standup';
 
-type ScrumBoardCardProps = { backlog: Backlog; projectKey: string | null | undefined };
+type ScrumBoardCardProps = {
+  backlog: Backlog;
+  projectKey: string | null | undefined;
+  standUp?: StandUp;
+};
 
-function Component({ backlog, projectKey }: ScrumBoardCardProps) {
+function Component({ backlog, projectKey, standUp }: ScrumBoardCardProps) {
   const navigate = useNavigate();
   const params = useParams();
+  const [addStandUpNote] = useAddStandUpNoteMutation();
+
+  const canAddToStandUpBoard = backlog.assignee !== null && backlog.assignee?.user_id !== undefined && standUp !== undefined;
+
+  const onClickBacklogMenuItem: MenuProps['onClick'] = async (e) => {
+    e.domEvent.stopPropagation(); // Stop the menu item click from bubbling up to the card
+    if (!canAddToStandUpBoard) {
+      message.error("Cannot perform action on unassigned backlog");
+      return;
+    }
+    const userId = backlog.assignee;
+    try {
+      await addStandUpNote({
+        stand_up_id: standUp.id,
+        content: backlog.summary,
+        column_id: Number(e.key),
+        user_id: userId!.user_id,
+      }).unwrap();
+      message.success("Added in standup board");
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const backlogMenuItems: MenuProps['items']= [
+    {
+      key: COLUMN_MAPPING.DONE,
+      label: 'Mark as Done in Standup'
+    },
+    {
+      key: COLUMN_MAPPING.NEXT,
+      label: 'Mark as Next in Standup'
+    },
+    {
+      key: COLUMN_MAPPING.BLOCKERS,
+      label: 'Mark as Blockers in Standup'
+    }
+  ];
+
+  const actions: React.ReactNode[] = [
+    (<Dropdown key="ellipsis" menu={{items: backlogMenuItems, onClick: onClickBacklogMenuItem}}>
+      <SettingOutlined onClick={(e) => e.stopPropagation()}/>
+    </Dropdown>),
+  ];
 
   return (
     <Card
       className="scrum-board-card-container"
       onClick={() => navigate(`/project/${params.projectId}/backlog/${backlog.backlog_id}`)}
+      actions={canAddToStandUpBoard ? actions: undefined}
     >
       <div className="scrum-board-card-summary">{backlog.summary}</div>
       <div className="scrum-board-card-details">

--- a/packages/frontend/src/components/cards/ScrumBoardCard.tsx
+++ b/packages/frontend/src/components/cards/ScrumBoardCard.tsx
@@ -35,10 +35,13 @@ function Component({ backlog, projectKey, standUp }: ScrumBoardCardProps) {
     const userId = backlog.assignee;
     try {
       await addStandUpNote({
-        stand_up_id: standUp.id,
-        content: backlog.summary,
-        column_id: Number(e.key),
-        user_id: userId!.user_id,
+        project_id: backlog.project_id,
+        standUpNote: {
+          stand_up_id: standUp.id,
+          content: backlog.summary,
+          column_id: Number(e.key),
+          user_id: userId!.user_id,
+        }
       }).unwrap();
       message.success("Added in standup board");
     } catch (err) {

--- a/packages/frontend/src/components/cards/__snapshots__/ScrumBoardCard.test.tsx.snap
+++ b/packages/frontend/src/components/cards/__snapshots__/ScrumBoardCard.test.tsx.snap
@@ -91,3 +91,176 @@ exports[`ScrumBoardCard test > renders scrum board card with correct details 1`]
   </div>
 </body>
 `;
+
+exports[`ScrumBoardCard test > renders scrum board card with standup options if stand up param is provided 1`] = `
+<body>
+  <div>
+    <div
+      data-rbd-droppable-context-id="1"
+      data-rbd-droppable-id="0"
+    >
+      <div
+        aria-describedby="rbd-hidden-text-1-hidden-text-3"
+        data-rbd-drag-handle-context-id="1"
+        data-rbd-drag-handle-draggable-id="0"
+        data-rbd-draggable-context-id="1"
+        data-rbd-draggable-id="0"
+        draggable="false"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="ant-card ant-card-bordered scrum-board-card-container"
+        >
+          <div
+            class="ant-card-body"
+          >
+            <div
+              class="scrum-board-card-summary"
+            >
+              A Test Summary
+            </div>
+            <div
+              class="scrum-board-card-details"
+            >
+              <div
+                class="backlog-card-id"
+              >
+                TEST-
+                111
+              </div>
+              <div
+                class="scrum-board-card-type"
+              >
+                story
+              </div>
+              <div
+                class="scrum-board-card-points points-active"
+              >
+                3
+              </div>
+              <div
+                class="scrum-board-card-priority very_high-priority"
+              >
+                Very High
+              </div>
+              <div
+                class="scrum-board-card-assignee"
+              >
+                <span
+                  class="ant-avatar ant-avatar-sm ant-avatar-circle assignee-avatar"
+                  style="background-color: rgb(105, 193, 165); color: black;"
+                >
+                  <span
+                    class="ant-avatar-string"
+                    style="transform: scale(1) translateX(-50%);"
+                  >
+                    B2
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+          <ul
+            class="ant-card-actions"
+          >
+            <li
+              style="width: 100%;"
+            >
+              <span>
+                <span
+                  aria-label="setting"
+                  class="anticon anticon-setting ant-dropdown-trigger ant-dropdown-open"
+                  role="img"
+                  tabindex="-1"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="setting"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M924.8 625.7l-65.5-56c3.1-19 4.7-38.4 4.7-57.8s-1.6-38.8-4.7-57.8l65.5-56a32.03 32.03 0 009.3-35.2l-.9-2.6a443.74 443.74 0 00-79.7-137.9l-1.8-2.1a32.12 32.12 0 00-35.1-9.5l-81.3 28.9c-30-24.6-63.5-44-99.7-57.6l-15.7-85a32.05 32.05 0 00-25.8-25.7l-2.7-.5c-52.1-9.4-106.9-9.4-159 0l-2.7.5a32.05 32.05 0 00-25.8 25.7l-15.8 85.4a351.86 351.86 0 00-99 57.4l-81.9-29.1a32 32 0 00-35.1 9.5l-1.8 2.1a446.02 446.02 0 00-79.7 137.9l-.9 2.6c-4.5 12.5-.8 26.5 9.3 35.2l66.3 56.6c-3.1 18.8-4.6 38-4.6 57.1 0 19.2 1.5 38.4 4.6 57.1L99 625.5a32.03 32.03 0 00-9.3 35.2l.9 2.6c18.1 50.4 44.9 96.9 79.7 137.9l1.8 2.1a32.12 32.12 0 0035.1 9.5l81.9-29.1c29.8 24.5 63.1 43.9 99 57.4l15.8 85.4a32.05 32.05 0 0025.8 25.7l2.7.5a449.4 449.4 0 00159 0l2.7-.5a32.05 32.05 0 0025.8-25.7l15.7-85a350 350 0 0099.7-57.6l81.3 28.9a32 32 0 0035.1-9.5l1.8-2.1c34.8-41.1 61.6-87.5 79.7-137.9l.9-2.6c4.5-12.3.8-26.3-9.3-35zM788.3 465.9c2.5 15.1 3.8 30.6 3.8 46.1s-1.3 31-3.8 46.1l-6.6 40.1 74.7 63.9a370.03 370.03 0 01-42.6 73.6L721 702.8l-31.4 25.8c-23.9 19.6-50.5 35-79.3 45.8l-38.1 14.3-17.9 97a377.5 377.5 0 01-85 0l-17.9-97.2-37.8-14.5c-28.5-10.8-55-26.2-78.7-45.7l-31.4-25.9-93.4 33.2c-17-22.9-31.2-47.6-42.6-73.6l75.5-64.5-6.5-40c-2.4-14.9-3.7-30.3-3.7-45.5 0-15.3 1.2-30.6 3.7-45.5l6.5-40-75.5-64.5c11.3-26.1 25.6-50.7 42.6-73.6l93.4 33.2 31.4-25.9c23.7-19.5 50.2-34.9 78.7-45.7l37.9-14.3 17.9-97.2c28.1-3.2 56.8-3.2 85 0l17.9 97 38.1 14.3c28.7 10.8 55.4 26.2 79.3 45.8l31.4 25.8 92.8-32.9c17 22.9 31.2 47.6 42.6 73.6L781.8 426l6.5 39.9zM512 326c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm79.2 255.2A111.6 111.6 0 01512 614c-29.9 0-58-11.7-79.2-32.8A111.6 111.6 0 01400 502c0-29.9 11.7-58 32.8-79.2C454 401.6 482.1 390 512 390c29.9 0 58 11.6 79.2 32.8A111.6 111.6 0 01624 502c0 29.9-11.7 58-32.8 79.2z"
+                    />
+                  </svg>
+                </span>
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    aria-atomic="true"
+    aria-live="assertive"
+    id="rbd-announcement-1"
+    style="position: absolute; width: 1px; height: 1px; margin: -1px; border: 0px; padding: 0px; overflow: hidden; clip-path: inset(100%);"
+  />
+  <div
+    id="rbd-hidden-text-1-hidden-text-3"
+    style="display: none;"
+  >
+    
+  Press space bar to start a drag.
+  When dragging you can use the arrow keys to move the item around and escape to cancel.
+  Some screen readers may require you to be in focus mode or to use your pass through key
+
+  </div>
+  <div>
+    <div
+      class="ant-dropdown ant-slide-up-appear ant-slide-up-appear-prepare ant-slide-up ant-dropdown-placement-bottomLeft"
+      style="--arrow-x: 0px; --arrow-y: 0px; left: -1000vw; top: -1000vh; box-sizing: border-box;"
+    >
+      <ul
+        class="ant-dropdown-menu ant-dropdown-menu-root ant-dropdown-menu-vertical ant-dropdown-menu-light"
+        data-menu-list="true"
+        role="menu"
+        tabindex="0"
+      >
+        <li
+          class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
+          role="menuitem"
+          tabindex="-1"
+        >
+          <span
+            class="ant-dropdown-menu-title-content"
+          >
+            Mark as Done in Standup
+          </span>
+        </li>
+        <li
+          class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
+          role="menuitem"
+          tabindex="-1"
+        >
+          <span
+            class="ant-dropdown-menu-title-content"
+          >
+            Mark as Next in Standup
+          </span>
+        </li>
+        <li
+          class="ant-dropdown-menu-item ant-dropdown-menu-item-only-child"
+          role="menuitem"
+          tabindex="-1"
+        >
+          <span
+            class="ant-dropdown-menu-title-content"
+          >
+            Mark as Blockers in Standup
+          </span>
+        </li>
+      </ul>
+      <div
+        aria-hidden="true"
+        style="display: none;"
+      />
+    </div>
+  </div>
+</body>
+`;

--- a/packages/frontend/src/components/forms/StandUpForm.tsx
+++ b/packages/frontend/src/components/forms/StandUpForm.tsx
@@ -1,11 +1,31 @@
 import React from 'react';
 import { DatePicker, Form } from 'antd';
+import dayjs from 'dayjs';
+
+type StandUpFormProps = {
+  isToday?: boolean;
+};
 
 // Renders form elements to input project name
-export default function StandUpForm(): JSX.Element {
+export default function StandUpForm({ isToday }: StandUpFormProps): JSX.Element {
   return (
-    <Form.Item label="Date" name="date" required rules={[{ required: true, message: 'Please set a date!' }]}>
-      <DatePicker />
-    </Form.Item>
+    isToday ? (
+      <Form.Item
+        label="Date"
+        name="date"
+        required
+        rules={[{ required: true, message: 'Please set a date!' }]}
+        initialValue={dayjs()}
+        >
+        <DatePicker
+          defaultValue={dayjs()}
+          disabled
+        />
+      </Form.Item>
+    ) : (
+      <Form.Item label="Date" name="date" required rules={[{ required: true, message: 'Please set a date!' }]}>
+        <DatePicker />
+      </Form.Item>
+    )
   );
 }

--- a/packages/frontend/src/components/modals/StandUpCreationModal.tsx
+++ b/packages/frontend/src/components/modals/StandUpCreationModal.tsx
@@ -13,7 +13,7 @@ const { Option } = Select;
  * @param course course that the project will attach to, skips second step
  */
 // eslint-disable-next-line react/require-default-props
-export default function StandUpCreationModal({ projectId }: { projectId: number }): JSX.Element {
+export default function StandUpCreationModal({ projectId, isToday }: { projectId: number, isToday?: boolean }): JSX.Element {
   const [addStandUp] = useAddStandUpMutation();
 
   const onFinish = useCallback(
@@ -36,10 +36,10 @@ export default function StandUpCreationModal({ projectId }: { projectId: number 
 
   return (
     <MultistepFormModal
-      title="Schedule Stand Up"
-      buttonChildren="Schedule Stand Up"
+      title={isToday? "Schedule Stand up for today": "Schedule Stand Up"}
+      buttonChildren={isToday? "Schedule Stand up for today": "Schedule Stand Up"}
       formName="stand-up-creation-form"
-      formSteps={[<StandUpForm />]}
+      formSteps={[<StandUpForm isToday={isToday} />]}
       onSubmit={onFinish}
       buttonType="primary"
     />

--- a/packages/frontend/src/helpers/dragAndDrop.tsx
+++ b/packages/frontend/src/helpers/dragAndDrop.tsx
@@ -1,5 +1,4 @@
 import { Draggable } from 'react-beautiful-dnd';
-
 type DraggableWrapperProps = { id: number; index: number };
 
 export const draggableWrapper = <P extends object>(
@@ -8,7 +7,17 @@ export const draggableWrapper = <P extends object>(
   return (props: P & DraggableWrapperProps) => (
     <Draggable draggableId={props.id.toString()} index={props.index}>
       {(provided) => (
-        <div ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
+        <div 
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+          // Draggables are not aligned in antd carousel
+          // Solution: https://stackoverflow.com/questions/54982182/react-beautiful-dnd-drag-out-of-position-problem
+          style={{ ...provided.draggableProps.style,
+            left: "auto !important",
+            top: "auto !important",
+          }}
+        >
           <WrappedComponent {...props} />
         </div>
       )}

--- a/packages/frontend/src/pages/projectPages/ScrumBoardPage.css
+++ b/packages/frontend/src/pages/projectPages/ScrumBoardPage.css
@@ -2,6 +2,7 @@
   display: inline-block;
   min-width: 100%;
   min-height: 100%;
+  transform: none;
 }
 
 .scrum-board-header {
@@ -10,4 +11,5 @@
   align-items: center;
   margin-bottom: 1em;
   gap: 1em;
+  transform: none;
 }

--- a/packages/frontend/src/pages/projectPages/ScrumBoardPage.css
+++ b/packages/frontend/src/pages/projectPages/ScrumBoardPage.css
@@ -9,4 +9,5 @@
   flex-direction: row;
   align-items: center;
   margin-bottom: 1em;
+  gap: 1em;
 }

--- a/packages/frontend/src/pages/projectPages/ScrumBoardPage.css
+++ b/packages/frontend/src/pages/projectPages/ScrumBoardPage.css
@@ -2,7 +2,6 @@
   display: inline-block;
   min-width: 100%;
   min-height: 100%;
-  transform: none;
 }
 
 .scrum-board-header {
@@ -11,5 +10,4 @@
   align-items: center;
   margin-bottom: 1em;
   gap: 1em;
-  transform: none;
 }

--- a/packages/frontend/src/pages/projectPages/ScrumBoardPage.tsx
+++ b/packages/frontend/src/pages/projectPages/ScrumBoardPage.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { Carousel, Spin } from 'antd';
 import { Sprint, useGetActiveSprintQuery, useGetSprintsByProjectIdQuery } from '../../api/sprint';
 import Container from '../../components/layouts/Container';
 import ScrumBoard from '../../components/board/ScrumBoard';
@@ -7,6 +8,13 @@ import { Heading } from '../../components/typography';
 
 import './ScrumBoardPage.css';
 import BacklogCreationModal from '../../components/modals/BacklogCreationModal';
+import { useGetStandUpHeadersByProjectIdQuery, useGetStandUpQuery } from '../../api/standup';
+import StandUpBoard from '../../components/board/StandUpBoard';
+import store from '../../app/store';
+import trofosApiSlice from '../../api';
+import useSocket from '../../api/socket/useSocket';
+import { UpdateType } from '../../api/socket/socket';
+import { useProjectIdParam } from '../../api/hooks';
 
 const getSprintHeading = (sprint: Sprint | undefined, activeSprint: Sprint | undefined): string | undefined => {
   if (!sprint) {
@@ -19,9 +27,56 @@ const getSprintHeading = (sprint: Sprint | undefined, activeSprint: Sprint | und
 };
 
 export default function ActiveScrumBoardPage(): JSX.Element {
-  const params = useParams();
-  const projectId = Number(params.projectId);
-  const { data: activeSprint } = useGetActiveSprintQuery(projectId);
+  const projectId = useProjectIdParam();
+  const { data: activeSprint, isLoading: isLoadingActiveSprint } = useGetActiveSprintQuery(projectId);
+  const { data: standUps, isLoading: isLoadingStandUpHeaders } = useGetStandUpHeadersByProjectIdQuery(projectId);
+  const [todaysStandUpId, setTodaysStandUpId] = useState<number | undefined>(undefined);
+  const { data: todaysStandUp, isLoading: isLoadingStandUp } = useGetStandUpQuery(
+    { id: todaysStandUpId! }, 
+    { skip: todaysStandUpId === undefined } // Skip the query if there's no standupId
+  );
+  
+  // Refetch active standup data upon update
+  const handleReset = useCallback(() => {
+    store.dispatch(trofosApiSlice.util.invalidateTags([{ type: 'StandUp', id: todaysStandUpId }]));
+  }, [todaysStandUpId]);
+  useSocket(UpdateType.STAND_UP_NOTES, todaysStandUpId?.toString(), handleReset);
+
+  const renderBody = () => {
+    return (
+      //<Carousel arrows draggable={false}>
+      <>
+        {activeSprint ? (
+        <div style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}>
+          <ScrumBoard projectId={projectId} sprint={activeSprint} />
+        </div>
+      ) : null}
+      {todaysStandUp ? (
+        <div style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}>
+          <StandUpBoard standUp={todaysStandUp} />
+        </div>
+      ) : null}
+      </>
+      //</></Carousel>
+    );
+  }
+
+  useEffect(() => {
+    if (standUps && standUps.length > 0) {
+      const isSameDay = (date1: Date, date2: Date) => (
+        date1.getFullYear() === date2.getFullYear() &&
+        date1.getMonth() === date2.getMonth() &&
+        date1.getDate() === date2.getDate()
+      );
+  
+      const todaysStandup = standUps?.find((s) => isSameDay(new Date(s.date), new Date()));
+      setTodaysStandUpId(todaysStandup?.id);
+    }
+  }, [standUps]);
+
+  if (isLoadingActiveSprint || isLoadingStandUpHeaders || isLoadingStandUp) {
+    return <Spin />;
+  }
 
   return (
     <Container noGap fullWidth className="scrum-board-container">
@@ -31,7 +86,7 @@ export default function ActiveScrumBoardPage(): JSX.Element {
         </Heading>
         {activeSprint && <BacklogCreationModal fixedSprint={activeSprint} title={'Create Backlog For This Sprint'} />}
       </div>
-      <ScrumBoard projectId={projectId} sprint={activeSprint} />
+      {renderBody()}
     </Container>
   );
 }

--- a/packages/frontend/src/pages/projectPages/ScrumBoardPage.tsx
+++ b/packages/frontend/src/pages/projectPages/ScrumBoardPage.tsx
@@ -60,23 +60,19 @@ export default function ActiveScrumBoardPage(): JSX.Element {
   const renderBody = () => {
     return (
       <Carousel draggable={false} ref={carouselRef}>
-        {activeSprint ? (
+        <div style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}>
+          {activeSprint && todaysStandUp && (
+            <Button onClick={handleViewStandUpBoard}>
+            View Today's Stand Up Board
+            </Button> 
+          )}
+          <ScrumBoard projectId={projectId} sprint={activeSprint} standUp={todaysStandUp}/>
+        </div>
+        {activeSprint && todaysStandUp ? (
           <div style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}>
-            {todaysStandUp && (
-             <Button onClick={handleViewStandUpBoard}>
-              View Today's Stand Up Board
-             </Button> 
-            )}
-            <ScrumBoard projectId={projectId} sprint={activeSprint} standUp={todaysStandUp}/>
-          </div>
-        ) : null}
-        {todaysStandUp ? (
-          <div style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}>
-            {activeSprint && (
-              <Button onClick={handleViewScrumBoard}>
-                View Active Scrum Board
-              </Button>
-            )}
+            <Button onClick={handleViewScrumBoard}>
+              View Active Scrum Board
+            </Button>
             <StandUpBoard standUp={todaysStandUp} />
           </div>
         ) : null}
@@ -108,7 +104,7 @@ export default function ActiveScrumBoardPage(): JSX.Element {
           {getSprintHeading(activeSprint, activeSprint)}
         </Heading>
         {activeSprint && <BacklogCreationModal fixedSprint={activeSprint} title={'Create Backlog For This Sprint'} />}
-        {!todaysStandUp && <StandUpCreationModal projectId={projectId} isToday/>}
+        {!todaysStandUp && activeSprint && <StandUpCreationModal projectId={projectId} isToday/>}
       </div>
       {renderBody()}
     </Container>

--- a/packages/frontend/src/pages/projectPages/ScrumBoardPage.tsx
+++ b/packages/frontend/src/pages/projectPages/ScrumBoardPage.tsx
@@ -34,7 +34,7 @@ export default function ActiveScrumBoardPage(): JSX.Element {
   const { data: standUps, isLoading: isLoadingStandUpHeaders } = useGetStandUpHeadersByProjectIdQuery(projectId);
   const [todaysStandUpId, setTodaysStandUpId] = useState<number | undefined>(undefined);
   const { data: todaysStandUp, isLoading: isLoadingStandUp } = useGetStandUpQuery(
-    { id: todaysStandUpId! }, 
+    { project_id: projectId, id: {id: todaysStandUpId!} }, 
     { skip: todaysStandUpId === undefined } // Skip the query if there's no standupId
   );
   const carouselRef = useRef<CarouselRef>(null);

--- a/packages/frontend/src/pages/projectPages/ScrumBoardPage.tsx
+++ b/packages/frontend/src/pages/projectPages/ScrumBoardPage.tsx
@@ -48,7 +48,7 @@ export default function ActiveScrumBoardPage(): JSX.Element {
       <>
         {activeSprint ? (
         <div style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}>
-          <ScrumBoard projectId={projectId} sprint={activeSprint} />
+          <ScrumBoard projectId={projectId} sprint={activeSprint} standUp={todaysStandUp}/>
         </div>
       ) : null}
       {todaysStandUp ? (

--- a/packages/frontend/src/pages/projectPages/ScrumBoardPage.tsx
+++ b/packages/frontend/src/pages/projectPages/ScrumBoardPage.tsx
@@ -15,6 +15,7 @@ import trofosApiSlice from '../../api';
 import useSocket from '../../api/socket/useSocket';
 import { UpdateType } from '../../api/socket/socket';
 import { useProjectIdParam } from '../../api/hooks';
+import StandUpCreationModal from '../../components/modals/StandUpCreationModal';
 
 const getSprintHeading = (sprint: Sprint | undefined, activeSprint: Sprint | undefined): string | undefined => {
   if (!sprint) {
@@ -47,15 +48,15 @@ export default function ActiveScrumBoardPage(): JSX.Element {
       //<Carousel arrows draggable={false}>
       <>
         {activeSprint ? (
-        <div style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}>
-          <ScrumBoard projectId={projectId} sprint={activeSprint} standUp={todaysStandUp}/>
-        </div>
-      ) : null}
-      {todaysStandUp ? (
-        <div style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}>
-          <StandUpBoard standUp={todaysStandUp} />
-        </div>
-      ) : null}
+          <div style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}>
+            <ScrumBoard projectId={projectId} sprint={activeSprint} standUp={todaysStandUp}/>
+          </div>
+        ) : null}
+        {todaysStandUp ? (
+          <div style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}>
+            <StandUpBoard standUp={todaysStandUp} />
+          </div>
+        ) : null}
       </>
       //</></Carousel>
     );
@@ -85,6 +86,7 @@ export default function ActiveScrumBoardPage(): JSX.Element {
           {getSprintHeading(activeSprint, activeSprint)}
         </Heading>
         {activeSprint && <BacklogCreationModal fixedSprint={activeSprint} title={'Create Backlog For This Sprint'} />}
+        {!todaysStandUp && <StandUpCreationModal projectId={projectId} isToday/>}
       </div>
       {renderBody()}
     </Container>

--- a/packages/frontend/src/pages/projectPages/StandUpBoardPage.tsx
+++ b/packages/frontend/src/pages/projectPages/StandUpBoardPage.tsx
@@ -12,7 +12,11 @@ import { Spin } from 'antd';
 export default function StandUpBoardPage(): JSX.Element {
   const params = useParams();
   const standUpId = Number(params.standUpId);
-  const { data: standUp, isLoading } = useGetStandUpQuery({ id: standUpId });
+  const projectId = Number(params.projectId);
+  const { data: standUp, isLoading } = useGetStandUpQuery({ 
+    project_id: projectId,
+    id: {id: standUpId}
+  });
 
   // Refetch active standup data upon update
   const handleReset = useCallback(() => {


### PR DESCRIPTION
<!-- Replace the #XX below with an issue number or the corresponding TROFOS ticket number-->

T3-23

<!-- Tag persons responsible for reviewing proposed changes -->

@thamruicong 

**Description**
Previously requested feature, to allow users to access the standup page while in the scrum board. This PR changes the UI to add shortcuts to quickly switch between the scrum board and today's standup board, while providing some controls to move tickets over to the stand up board easily

**Other Information**

Allows users to create standup for today in scrum board:

<img width="767" alt="image" src="https://github.com/user-attachments/assets/6d288f8c-d1ed-4433-a75b-2dd0f4271ece">

Assigned backlogs can have these actions:

<img width="713" alt="image" src="https://github.com/user-attachments/assets/f485be1b-205c-4883-aef9-7ca220b934fd">

Standup board after copying backlog:

<img width="698" alt="image" src="https://github.com/user-attachments/assets/1f7d8cba-4e05-4912-9612-ba2d787026b2">


<!-- Add any other information below or remove this line completely -->

**Checklist**

- [X] My pull request has a descriptive title (not a vague title like `Update README.md`)

- [X] My pull request targets the `master` branch of the repository only

- [X] My commits follows these [commit message guidelines](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53)

- [ ] I added tests for the changes I made (if applicable)

- [ ] I added or updated documentation (if applicable)

- [X] I have ran the project and its tests locally and verified that there are no visible errors

- [ ] Includes DB Migration
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
