### PR TITLE
Fix burndown chart issue of going against x-axis

### DIFF
--- a/packages/frontend/src/components/visualization/BurnDownChart.tsx
+++ b/packages/frontend/src/components/visualization/BurnDownChart.tsx
@@ -53,6 +53,7 @@ export function BurnDownChart(props: BurnDownChartProps): JSX.Element {
         type: 'line',  // Vertical line for sprint end
         start: [sprint.end_date, 'min'],
         end: [sprint.end_date, 'max'],
+        offsetX: -10,
         style: {
           stroke: '#52c41a', // Green color for the line
           lineDash: [4, 4],  // Dashed line style

--- a/packages/frontend/src/components/visualization/BurnDownChart.tsx
+++ b/packages/frontend/src/components/visualization/BurnDownChart.tsx
@@ -16,7 +16,7 @@ export function BurnDownChart(props: BurnDownChartProps): JSX.Element {
   const { backlogHistory, sprint, includeTitle } = props;
   const { storyPointData } = useBurndownChart(backlogHistory, sprint?.id, sprint?.end_date);
   const isDarkTheme = useAppSelector((state) => state.themeSlice.isDarkTheme);
-
+  
   const config: React.ComponentProps<typeof Line> = {
     data: storyPointData,
     theme: isDarkTheme ? 'dark' : 'default',
@@ -27,6 +27,11 @@ export function BurnDownChart(props: BurnDownChartProps): JSX.Element {
       date: {
         type: 'time',
       },
+    },
+    yAxis: {
+      title: {
+        text: 'Story Points',
+      }
     },
     tooltip: {
       // eslint-disable-next-line react/no-unstable-nested-components

--- a/packages/frontend/src/components/visualization/BurnDownChart.tsx
+++ b/packages/frontend/src/components/visualization/BurnDownChart.tsx
@@ -33,6 +33,38 @@ export function BurnDownChart(props: BurnDownChartProps): JSX.Element {
         text: 'Story Points',
       }
     },
+    annotations: sprint ? [
+      {
+        type: 'line',  // Vertical line for sprint start
+        start: [sprint.start_date, 'min'],
+        end: [sprint.start_date, 'max'],
+        style: {
+          stroke: '#ff4d4f', // Red color for the line
+          lineDash: [4, 4],  // Dashed line style
+          lineWidth: 2,
+        },
+        text: {
+          content: 'Sprint Start',
+          position: 'start',
+          style: { fill: '#ff4d4f' }, // Red color for the text
+        },
+      },
+      {
+        type: 'line',  // Vertical line for sprint end
+        start: [sprint.end_date, 'min'],
+        end: [sprint.end_date, 'max'],
+        style: {
+          stroke: '#52c41a', // Green color for the line
+          lineDash: [4, 4],  // Dashed line style
+          lineWidth: 2,
+        },
+        text: {
+          content: 'Sprint End',
+          position: 'start',
+          style: { fill: '#52c41a' }, // Green color for the text
+        },
+      },
+    ] : undefined,
     tooltip: {
       // eslint-disable-next-line react/no-unstable-nested-components
       customContent: (title, items) => {


### PR DESCRIPTION
<!-- Replace the #XX below with an issue number or the corresponding TROFOS ticket number-->

#T3-30

<!-- Tag persons responsible for reviewing proposed changes -->

@thamruicong 

**Description**
Burndown chart library plotted points according to their order, not value. so (2024-09-27, Y1), (2024-09-26, Y2) will be plotted in their order, causing the line to go left sometimes. 

I edited the logic of burndown chart data generation, removing the part that added points that caused the data to be out of order and handled made the backlog history -> point generation logic a bit more robust, handling the new data we pass in.

- Burndown chart line will only go right now
- added logic to track backlogs only relevant to current sprint, if selected (see case 1/ case2 logic in `useBurnDown`)
- Added lines to indicate sprint start and sprint end

<!-- Add a descriptive title below -->

**Other Information**
<img width="716" alt="image" src="https://github.com/user-attachments/assets/c091df95-d222-419f-9ab1-a73cd6fedf44">


<!-- Add any other information below or remove this line completely -->

**Checklist**

- [X] My pull request has a descriptive title (not a vague title like `Update README.md`)

- [X] My pull request targets the `master` branch of the repository only

- [X] My commits follows these [commit message guidelines](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53)

- [ ] I added tests for the changes I made (if applicable)

- [ ] I added or updated documentation (if applicable)

- [X] I have ran the project and its tests locally and verified that there are no visible errors

- [ ] Includes DB Migration
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
