### PR TITLE
Fix 'email settings' not visible in dark mode and sider icon not visible in light mode

### DIFF
--- a/packages/frontend/src/components/forms/ProjectUserSettingsForm.tsx
+++ b/packages/frontend/src/components/forms/ProjectUserSettingsForm.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { message, Switch } from 'antd';
+import { message, Switch, Typography, Row, Col } from 'antd';
 import { useParams } from 'react-router-dom';
 import { useUpdateUserSettingsMutation } from '../../api/project';
 import { ProjectUserSettings } from '../../api/types';
-import './ProjectUserSettingsForm.css';
 
 export default function ProjectUserSettingsForm(props: { projectUserSettings: ProjectUserSettings }): JSX.Element {
   const { projectUserSettings } = props;
@@ -26,8 +25,14 @@ export default function ProjectUserSettingsForm(props: { projectUserSettings: Pr
 
   return (
     <div className="project-user-settings-container">
-      <span className="settings-label">Email notification: </span>
-      <Switch checked={projectUserSettings?.email_notification} onChange={handleEmailNotificationOnChange} />
+      <Row gutter={4}>
+        <Col>
+          <Typography>Email Notification:</Typography>
+        </Col>
+        <Col>
+          <Switch checked={projectUserSettings?.email_notification} onChange={handleEmailNotificationOnChange} />
+        </Col>
+      </Row>
     </div>
   );
 }

--- a/packages/frontend/src/templates/MainLayout.tsx
+++ b/packages/frontend/src/templates/MainLayout.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Col, Layout, Row, MenuProps, Dropdown, Menu, Typography, Space, Image } from 'antd';
-import { BookOutlined, HomeOutlined, KeyOutlined, ProjectOutlined, SettingOutlined } from '@ant-design/icons';
+import { BookOutlined, HomeOutlined, KeyOutlined, ProjectOutlined, SettingOutlined, UnorderedListOutlined } from '@ant-design/icons';
 import { Link, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 
@@ -116,6 +116,7 @@ export default function MainLayout() {
   const { currentProjects: projects } = useCurrentAndPastProjects();
   const { currentCourses: courses } = useCurrentAndPastCourses();
   const { data: userInfo, isLoading } = useGetUserInfoQuery();
+  const isDarkTheme = useAppSelector((state) => state.themeSlice.isDarkTheme);
 
   const location = useLocation();
   const navigate = useNavigate();
@@ -221,7 +222,13 @@ export default function MainLayout() {
 
   return (
     <Layout style={{ minHeight: '100vh' }}>
-      <Sider breakpoint="lg" collapsedWidth="0" onBreakpoint={setIsBroken} className="main-layout-sider">
+      <Sider
+        breakpoint="lg"
+        collapsedWidth="0"
+        onBreakpoint={setIsBroken}
+        className="main-layout-sider"
+        trigger={<UnorderedListOutlined style={{color: isDarkTheme ? '#FFF' : '#000'}}/>}
+      >
         <Link to="/" className="logo">
           <Image width={40} src="favicon.ico" preview={false} alt="Trofos logo" />
           <div>Trofos</div>


### PR DESCRIPTION
<!-- Replace the #XX below with an issue number or the corresponding TROFOS ticket number-->

Closes #181 

<!-- Tag persons responsible for reviewing proposed changes -->

@thamruicong 

**Description**

<!-- Add a descriptive title below -->

1. Fixes bug reported by user where text doesn't change color in dark mode (normal span is used)
2. Fix bug where antd doesn't change sider icon color to black in light mode

<img width="368" alt="image" src="https://github.com/user-attachments/assets/4de65acd-ef59-4d90-9dd0-e8b0609a0779">

Originally this icon is white in light mode and can't be seen

**Other Information**

<!-- Add any other information below or remove this line completely -->

**Checklist**

- [X] My pull request has a descriptive title (not a vague title like `Update README.md`)

- [X] My pull request targets the `master` branch of the repository only

- [X] My commits follows these [commit message guidelines](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53)

- [ ] I added tests for the changes I made (if applicable)

- [ ] I added or updated documentation (if applicable)

- [X] I have ran the project and its tests locally and verified that there are no visible errors

- [ ] Includes DB Migration
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
