### PR TITLE
Make scrum board item look nicer and give backlog types icons

### DIFF
--- a/packages/frontend/src/components/cards/ScrumBoardCard.test.tsx
+++ b/packages/frontend/src/components/cards/ScrumBoardCard.test.tsx
@@ -14,7 +14,7 @@ describe('ScrumBoardCard test', () => {
     const mockProjectKey = 'TEST';
     const mockIndex = 0;
     const mockDroppableId = '0';
-    const { baseElement, debug } = render(
+    const { baseElement, debug, container } = render(
       <Provider store={store}>
         <BrowserRouter>
           <DragDropContext onDragEnd={vi.fn()}>
@@ -35,7 +35,7 @@ describe('ScrumBoardCard test', () => {
         </BrowserRouter>
       </Provider>,
     );
-    return { baseElement, debug };
+    return { baseElement, debug, container };
   }
   const mockBacklog: Backlog = {
     backlog_id: 111,
@@ -68,9 +68,10 @@ describe('ScrumBoardCard test', () => {
   };
 
   it('renders scrum board card with correct details', () => {
-    const { baseElement } = setup(mockBacklog);
+    const { baseElement, container } = setup(mockBacklog);
+    const storySvg = container.querySelector("[data-icon='wallet']") as HTMLImageElement;
+    expect(storySvg).toBeInTheDocument();
     expect(screen.getByText(mockBacklog.summary)).toBeInTheDocument();
-    expect(screen.getByText(mockBacklog.type)).toBeInTheDocument();
     expect(screen.getByText(mockBacklog?.points?.toString() as string)).toBeInTheDocument();
 
     // Compare with snapshot to ensure structure remains the same
@@ -78,9 +79,10 @@ describe('ScrumBoardCard test', () => {
   });
 
   it('renders scrum board card with standup options if stand up param is provided', async () => {
-    const { baseElement, debug } = setup(mockBacklog, mockStandUp);
+    const { baseElement, debug, container } = setup(mockBacklog, mockStandUp);
+    const storySvg = container.querySelector("[data-icon='wallet']") as HTMLImageElement;
+    expect(storySvg).toBeInTheDocument();
     expect(screen.getByText(mockBacklog.summary)).toBeInTheDocument();
-    expect(screen.getByText(mockBacklog.type)).toBeInTheDocument();
     expect(screen.getByText(mockBacklog?.points?.toString() as string)).toBeInTheDocument();
     const dropdownButton = screen.getByLabelText(/setting/i);
     fireEvent.mouseOver(dropdownButton);

--- a/packages/frontend/src/components/cards/ScrumBoardCard.tsx
+++ b/packages/frontend/src/components/cards/ScrumBoardCard.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { Card, Dropdown, message } from 'antd';
+import { Card, Dropdown, Space, Tag, Tooltip, message } from 'antd';
 import { SettingOutlined } from '@ant-design/icons';
 import { useNavigate, useParams } from 'react-router-dom';
 import { isEqual } from 'lodash';
 import { UserAvatar } from '../avatar/UserAvatar';
 import type { Backlog } from '../../api/types';
 import { draggableWrapper } from '../../helpers/dragAndDrop';
-import { BACKLOG_PRIORITY_OPTIONS } from '../../helpers/constants';
+import { BACKLOG_PRIORITY_OPTIONS, BACKLOG_TYPE_OPTIONS } from '../../helpers/constants';
 import './ScrumBoardCard.css';
 import { MenuProps } from 'antd/lib';
 import { COLUMN_MAPPING } from '../board/StandUpBoard/StandUpBoard';
@@ -70,6 +70,27 @@ function Component({ backlog, projectKey, standUp }: ScrumBoardCardProps) {
     </Dropdown>),
   ];
 
+  const storyPointDisplay = (value: number | null) => {
+    let color;
+    if (value === null) {
+      color = 'grey';
+    } else if (value <= 2) {
+      color = 'green';
+    } else if (value <= 4) {
+      color = 'orange';
+    } else {
+      color = 'red';
+    }
+
+    return (
+      <Tooltip title="Story Points">
+        <Tag color={color}>
+          {value === null ? '-' : value}
+        </Tag>
+      </Tooltip>
+    )
+  }
+
   return (
     <Card
       className="scrum-board-card-container"
@@ -77,13 +98,16 @@ function Component({ backlog, projectKey, standUp }: ScrumBoardCardProps) {
       actions={canAddToStandUpBoard ? actions: undefined}
     >
       <div className="scrum-board-card-summary">{backlog.summary}</div>
-      <div className="scrum-board-card-details">
-        <div className="backlog-card-id">
-          {projectKey ? `${projectKey}-` : ''}
-          {backlog.backlog_id}
+      <Space style={{ paddingTop: '20px' }} wrap>
+        <Tooltip title={backlog.type}>
+          {BACKLOG_TYPE_OPTIONS.find((t) => t.value===backlog.type)?.icon}
+        </Tooltip>
+        <div>
+          {(projectKey ? `${projectKey}-` : '') + backlog.backlog_id}
         </div>
-        <div className="scrum-board-card-type">{backlog.type}</div>
-        <div className={`scrum-board-card-points ${backlog.points ? 'points-active' : ''}`}>{backlog.points}</div>
+        <div style={{ marginLeft: '6px' }}>
+          {storyPointDisplay(backlog.points)}
+        </div>
         <div className={`scrum-board-card-priority ${backlog.priority}-priority`}>
           {BACKLOG_PRIORITY_OPTIONS.find((v) => v.value == backlog.priority)?.label}
         </div>
@@ -109,7 +133,7 @@ function Component({ backlog, projectKey, standUp }: ScrumBoardCardProps) {
             />
           </div>
         )}
-      </div>
+      </Space>
     </Card>
   );
 }

--- a/packages/frontend/src/components/cards/__snapshots__/BacklogListingCard.test.tsx.snap
+++ b/packages/frontend/src/components/cards/__snapshots__/BacklogListingCard.test.tsx.snap
@@ -85,9 +85,39 @@ exports[`BacklogCard test > renders backlog card with correct details 1`] = `
         </span>
         <span
           class="ant-select-selection-item"
-          title="Story"
         >
-          Story
+          <div
+            class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+          >
+            <div
+              class="ant-space-item"
+            >
+              <span
+                aria-label="wallet"
+                class="anticon anticon-wallet"
+                role="img"
+              >
+                <svg
+                  aria-hidden="true"
+                  data-icon="wallet"
+                  fill="currentColor"
+                  focusable="false"
+                  height="1em"
+                  viewBox="64 64 896 896"
+                  width="1em"
+                >
+                  <path
+                    d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 464H528V448h312v128zm0 264H184V184h656v200H496c-17.7 0-32 14.3-32 32v192c0 17.7 14.3 32 32 32h344v200zM580 512a40 40 0 1080 0 40 40 0 10-80 0z"
+                  />
+                </svg>
+              </span>
+            </div>
+            <div
+              class="ant-space-item"
+            >
+              Story
+            </div>
+          </div>
         </span>
       </div>
       <span

--- a/packages/frontend/src/components/cards/__snapshots__/ScrumBoardCard.test.tsx.snap
+++ b/packages/frontend/src/components/cards/__snapshots__/ScrumBoardCard.test.tsx.snap
@@ -29,43 +29,79 @@ exports[`ScrumBoardCard test > renders scrum board card with correct details 1`]
               A Test Summary
             </div>
             <div
-              class="scrum-board-card-details"
+              class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+              style="flex-wrap: wrap; padding-top: 20px;"
             >
               <div
-                class="backlog-card-id"
-              >
-                TEST-
-                111
-              </div>
-              <div
-                class="scrum-board-card-type"
-              >
-                story
-              </div>
-              <div
-                class="scrum-board-card-points points-active"
-              >
-                3
-              </div>
-              <div
-                class="scrum-board-card-priority very_high-priority"
-              >
-                Very High
-              </div>
-              <div
-                class="scrum-board-card-assignee"
+                class="ant-space-item"
               >
                 <span
-                  class="ant-avatar ant-avatar-sm ant-avatar-circle assignee-avatar"
-                  style="background-color: rgb(105, 193, 165); color: black;"
+                  aria-label="wallet"
+                  class="anticon anticon-wallet"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="wallet"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 464H528V448h312v128zm0 264H184V184h656v200H496c-17.7 0-32 14.3-32 32v192c0 17.7 14.3 32 32 32h344v200zM580 512a40 40 0 1080 0 40 40 0 10-80 0z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                class="ant-space-item"
+              >
+                <div>
+                  TEST-111
+                </div>
+              </div>
+              <div
+                class="ant-space-item"
+              >
+                <div
+                  style="margin-left: 6px;"
                 >
                   <span
-                    class="ant-avatar-string"
-                    style="transform: scale(1) translateX(-50%);"
+                    class="ant-tag ant-tag-orange"
                   >
-                    B2
+                    3
                   </span>
-                </span>
+                </div>
+              </div>
+              <div
+                class="ant-space-item"
+              >
+                <div
+                  class="scrum-board-card-priority very_high-priority"
+                >
+                  Very High
+                </div>
+              </div>
+              <div
+                class="ant-space-item"
+              >
+                <div
+                  class="scrum-board-card-assignee"
+                >
+                  <span
+                    class="ant-avatar ant-avatar-sm ant-avatar-circle assignee-avatar"
+                    style="background-color: rgb(105, 193, 165); color: black;"
+                  >
+                    <span
+                      class="ant-avatar-string"
+                      style="transform: scale(1) translateX(-50%);"
+                    >
+                      B2
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>
@@ -121,43 +157,79 @@ exports[`ScrumBoardCard test > renders scrum board card with standup options if 
               A Test Summary
             </div>
             <div
-              class="scrum-board-card-details"
+              class="ant-space ant-space-horizontal ant-space-align-center ant-space-gap-row-small ant-space-gap-col-small"
+              style="flex-wrap: wrap; padding-top: 20px;"
             >
               <div
-                class="backlog-card-id"
-              >
-                TEST-
-                111
-              </div>
-              <div
-                class="scrum-board-card-type"
-              >
-                story
-              </div>
-              <div
-                class="scrum-board-card-points points-active"
-              >
-                3
-              </div>
-              <div
-                class="scrum-board-card-priority very_high-priority"
-              >
-                Very High
-              </div>
-              <div
-                class="scrum-board-card-assignee"
+                class="ant-space-item"
               >
                 <span
-                  class="ant-avatar ant-avatar-sm ant-avatar-circle assignee-avatar"
-                  style="background-color: rgb(105, 193, 165); color: black;"
+                  aria-label="wallet"
+                  class="anticon anticon-wallet"
+                  role="img"
+                >
+                  <svg
+                    aria-hidden="true"
+                    data-icon="wallet"
+                    fill="currentColor"
+                    focusable="false"
+                    height="1em"
+                    viewBox="64 64 896 896"
+                    width="1em"
+                  >
+                    <path
+                      d="M880 112H144c-17.7 0-32 14.3-32 32v736c0 17.7 14.3 32 32 32h736c17.7 0 32-14.3 32-32V144c0-17.7-14.3-32-32-32zm-40 464H528V448h312v128zm0 264H184V184h656v200H496c-17.7 0-32 14.3-32 32v192c0 17.7 14.3 32 32 32h344v200zM580 512a40 40 0 1080 0 40 40 0 10-80 0z"
+                    />
+                  </svg>
+                </span>
+              </div>
+              <div
+                class="ant-space-item"
+              >
+                <div>
+                  TEST-111
+                </div>
+              </div>
+              <div
+                class="ant-space-item"
+              >
+                <div
+                  style="margin-left: 6px;"
                 >
                   <span
-                    class="ant-avatar-string"
-                    style="transform: scale(1) translateX(-50%);"
+                    class="ant-tag ant-tag-orange"
                   >
-                    B2
+                    3
                   </span>
-                </span>
+                </div>
+              </div>
+              <div
+                class="ant-space-item"
+              >
+                <div
+                  class="scrum-board-card-priority very_high-priority"
+                >
+                  Very High
+                </div>
+              </div>
+              <div
+                class="ant-space-item"
+              >
+                <div
+                  class="scrum-board-card-assignee"
+                >
+                  <span
+                    class="ant-avatar ant-avatar-sm ant-avatar-circle assignee-avatar"
+                    style="background-color: rgb(105, 193, 165); color: black;"
+                  >
+                    <span
+                      class="ant-avatar-string"
+                      style="transform: scale(1) translateX(-50%);"
+                    >
+                      B2
+                    </span>
+                  </span>
+                </div>
               </div>
             </div>
           </div>

--- a/packages/frontend/src/components/dropdowns/BacklogCardType.css
+++ b/packages/frontend/src/components/dropdowns/BacklogCardType.css
@@ -1,5 +1,5 @@
 .backlog-card-type {
-  width: 72px;
+  width: 78px;
 }
 
 .backlog-card-type.ant-select-single.ant-select-show-arrow .ant-select-selection-item {

--- a/packages/frontend/src/components/dropdowns/BacklogCardType.tsx
+++ b/packages/frontend/src/components/dropdowns/BacklogCardType.tsx
@@ -3,14 +3,9 @@ import { message, Select } from 'antd';
 import { useParams } from 'react-router-dom';
 import { useUpdateBacklogMutation } from '../../api/socket/backlogHooks';
 import './BacklogCardType.css';
+import { BACKLOG_TYPE_OPTIONS } from '../../helpers/constants';
 
 type BacklogType = 'story' | 'task' | 'bug';
-
-const BACKLOG_TYPE_OPTIONS = [
-  { value: 'story', label: 'Story' },
-  { value: 'task', label: 'Task' },
-  { value: 'bug', label: 'Bug' },
-];
 
 export default function BacklogCardType(props: { backlogId: number; currentType: BacklogType }) {
   const { currentType, backlogId } = props;

--- a/packages/frontend/src/components/fields/BacklogSelect.tsx
+++ b/packages/frontend/src/components/fields/BacklogSelect.tsx
@@ -78,7 +78,7 @@ function BacklogSelect(props: BacklogSelectPropsTypes): JSX.Element {
         >
           {options.map((option) => (
             <Option key={option.id} value={option.id}>
-              {option.name}
+              {option.labelComponent || option.name}
             </Option>
           ))}
         </Select>

--- a/packages/frontend/src/helpers/BacklogModal.types.ts
+++ b/packages/frontend/src/helpers/BacklogModal.types.ts
@@ -8,6 +8,7 @@ export interface BacklogFormFields extends FormData {
 export type BacklogSelectTypes = {
   id: string | number;
   name: string;
+  labelComponent?: JSX.Element;
 };
 
 export type BacklogUserSelectTypes = {

--- a/packages/frontend/src/helpers/constants.tsx
+++ b/packages/frontend/src/helpers/constants.tsx
@@ -1,3 +1,11 @@
+import React from 'react';
+import {
+  CheckSquareOutlined,
+  BugOutlined,
+  WalletOutlined,
+} from '@ant-design/icons';
+import { Space } from 'antd';
+
 /* eslint-disable import/prefer-default-export */
 const UserPermissionActions = {
   READ_COURSE: 'read_course',
@@ -33,4 +41,41 @@ const BACKLOG_PRIORITY_OPTIONS = [
   { value: 'very_low', label: 'Very Low' },
 ];
 
-export { UserPermissionActions, COURSE_MANAGER_ACTIONS, BACKLOG_PRIORITY_OPTIONS, MANAGE_API_KEY_ACTIONS };
+const BACKLOG_TYPE_OPTIONS = [
+  {
+    value: 'story',
+    label: (
+      <Space>
+        <WalletOutlined />
+        Story
+      </Space>
+    ),
+    icon: <WalletOutlined />
+  },
+  {
+    value: 'task',
+    label: (
+      <Space>
+        <CheckSquareOutlined />
+        Task
+      </Space>
+    ),
+    icon: <CheckSquareOutlined /> },
+  { 
+    value: 'bug',
+    label: (
+      <Space>
+        <BugOutlined />
+        Bug
+      </Space>
+    ),
+    icon: <BugOutlined /> },
+];
+
+export {
+  UserPermissionActions,
+  COURSE_MANAGER_ACTIONS,
+  BACKLOG_PRIORITY_OPTIONS,
+  MANAGE_API_KEY_ACTIONS,
+  BACKLOG_TYPE_OPTIONS,
+};

--- a/packages/frontend/src/pages/Backlog.tsx
+++ b/packages/frontend/src/pages/Backlog.tsx
@@ -19,6 +19,7 @@ import BacklogComment from '../components/fields/BacklogComment';
 import BacklogList from '../components/lists/BacklogList';
 import StrictModeDroppable from '../components/dnd/StrictModeDroppable';
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
+import { BACKLOG_TYPE_OPTIONS } from '../helpers/constants';
 
 function Backlog(): JSX.Element {
   const { Title } = Typography;
@@ -26,13 +27,15 @@ function Backlog(): JSX.Element {
   const [form] = Form.useForm();
   const [updateBacklog] = useUpdateBacklogMutation();
 
-  // These constants will most likely be passed down as props or
-  // fetched from an API. Currently hardcoded for developement.
-  const TYPES: BacklogSelectTypes[] = [
-    { id: 'story', name: 'Story' },
-    { id: 'task', name: 'Task' },
-    { id: 'bug', name: 'Bug' },
-  ];
+  const TYPES: BacklogSelectTypes[] = BACKLOG_TYPE_OPTIONS.map((type) => (
+    {
+      id: type.value,
+      name: type.value,
+      labelComponent: type.label,
+    }
+  ))
+
+
   const PRIORITIES: BacklogSelectTypes[] = [
     { id: 'very_high', name: 'Very High' },
     { id: 'high', name: 'High' },


### PR DESCRIPTION
<!-- Replace the #XX below with an issue number or the corresponding TROFOS ticket number-->

T3-56

<!-- Tag persons responsible for reviewing proposed changes -->

@thamruicong 

**Description**

Improve UI of scrum board and backlog type by adding icons

Old:
<img width="203" alt="image" src="https://github.com/user-attachments/assets/25e6f5f8-8721-4681-9a75-812aaff09bab">

New:
<img width="218" alt="image" src="https://github.com/user-attachments/assets/70408008-a4f5-4c41-a8cb-4dc4b1e8901f">

New:
<img width="760" alt="image" src="https://github.com/user-attachments/assets/5daf7313-54e6-4520-8c5a-deb8846b3625">

New:
<img width="276" alt="image" src="https://github.com/user-attachments/assets/3a5fca3b-95d2-413b-a52c-770be2bc9b16">


<!-- Add a descriptive title below -->

**Other Information**

<!-- Add any other information below or remove this line completely -->

**Checklist**

- [X] My pull request has a descriptive title (not a vague title like `Update README.md`)

- [X] My pull request targets the `master` branch of the repository only

- [X] My commits follows these [commit message guidelines](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53)

- [X] I added tests for the changes I made (if applicable)

- [ ] I added or updated documentation (if applicable)

- [X] I have ran the project and its tests locally and verified that there are no visible errors

- [ ] Includes DB Migration
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
