### PR TITLE
Fix scrum board- standup UI overflow bug

### DIFF
--- a/packages/frontend/src/components/board/ScrumBoard.css
+++ b/packages/frontend/src/components/board/ScrumBoard.css
@@ -1,7 +1,3 @@
-.scrum-board-drag-drop-context {
-  padding-bottom: 40px;
-}
-
 .scrum-board-status-container {
   display: flex;
 }

--- a/packages/frontend/src/components/board/ScrumBoard.tsx
+++ b/packages/frontend/src/components/board/ScrumBoard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Alert, message, Typography, Card, Space } from 'antd';
+import { Alert, message, Typography, Card, Space, Layout } from 'antd';
 import { DragDropContext, DropResult } from 'react-beautiful-dnd';
 
 import { useUpdateBacklogMutation } from '../../api/backlog';
@@ -13,6 +13,7 @@ import './ScrumBoard.css';
 import { StandUp } from '../../api/standup';
 
 const { Title } = Typography;
+const { Content } = Layout;
 
 type ScrumBoardProps = {
   projectId: number;
@@ -154,7 +155,7 @@ export default function ScrumBoard({ projectId, sprint, standUp }: ScrumBoardPro
   };
 
   return (
-    <div className="scrum-board-drag-drop-context">
+    <Content style={{ paddingBottom: '40px', overflowX: 'auto' }}>
       {!backlogs && (
         <Alert
           className="scrum-board-warning"
@@ -171,6 +172,6 @@ export default function ScrumBoard({ projectId, sprint, standUp }: ScrumBoardPro
         ))}
       </div>
       <DragDropContext onDragEnd={onDragEnd}>{renderDroppables()}</DragDropContext>
-    </div>
+    </Content>
   );
 }

--- a/packages/frontend/src/components/board/StandUpBoard/StandUpBoard.tsx
+++ b/packages/frontend/src/components/board/StandUpBoard/StandUpBoard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Typography, Card } from 'antd';
+import { Typography, Card, Layout } from 'antd';
 import StandUpColumn from './StandUpColumn';
 import { StandUp } from '../../../api/standup';
 import { useGetProjectQuery } from '../../../api/project';
@@ -9,6 +9,7 @@ import dayjs from 'dayjs';
 import './StandUpBoard.css';
 
 const { Title } = Typography;
+const { Content } = Layout;
 
 type StandUpBoardProps = { standUp: StandUp; readOnly?: boolean };
 
@@ -26,7 +27,7 @@ export default function StandUpBoard({ standUp, readOnly }: StandUpBoardProps): 
 
   const columnNames = ["What's Done?", 'What Next?', 'Blockers?'];
   return (
-    <>
+    <Content style={{ overflowX: 'auto' }}>
       <Heading>{dayjs(standUp.date).format('dddd, DD MMM YYYY')}</Heading>
       <div className="standup-board-status-container">
         {columnNames.map((columnName, index) => {
@@ -63,6 +64,6 @@ export default function StandUpBoard({ standUp, readOnly }: StandUpBoardProps): 
           </div>
         );
       })}
-    </>
+    </Content>
   );
 }

--- a/packages/frontend/src/pages/projectPages/ScrumBoardPage.tsx
+++ b/packages/frontend/src/pages/projectPages/ScrumBoardPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Button, Carousel, Spin } from 'antd';
+import { Button, Carousel, Space, Spin } from 'antd';
 import type { CarouselRef } from 'antd/es/carousel';
 import { Sprint, useGetActiveSprintQuery, useGetSprintsByProjectIdQuery } from '../../api/sprint';
 import Container from '../../components/layouts/Container';
@@ -59,22 +59,24 @@ export default function ActiveScrumBoardPage(): JSX.Element {
 
   const renderBody = () => {
     return (
-      <Carousel draggable={false} ref={carouselRef}>
-        <div style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}>
+      <Carousel draggable={false} ref={carouselRef} dots={false}>
+        {/* <div style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}> */}
+        <Space direction='vertical'>
           {activeSprint && todaysStandUp && (
             <Button onClick={handleViewStandUpBoard}>
             View Today's Stand Up Board
             </Button> 
           )}
           <ScrumBoard projectId={projectId} sprint={activeSprint} standUp={todaysStandUp}/>
-        </div>
+        </Space>
         {activeSprint && todaysStandUp ? (
-          <div style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}>
+          // <div> style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}>
+          <Space direction='vertical'>
             <Button onClick={handleViewScrumBoard}>
               View Active Scrum Board
             </Button>
             <StandUpBoard standUp={todaysStandUp} />
-          </div>
+          </Space>
         ) : null}
       </Carousel>
     );

--- a/packages/frontend/src/pages/projectPages/ScrumBoardPage.tsx
+++ b/packages/frontend/src/pages/projectPages/ScrumBoardPage.tsx
@@ -60,7 +60,6 @@ export default function ActiveScrumBoardPage(): JSX.Element {
   const renderBody = () => {
     return (
       <Carousel draggable={false} ref={carouselRef} dots={false}>
-        {/* <div style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}> */}
         <Space direction='vertical'>
           {activeSprint && todaysStandUp && (
             <Button onClick={handleViewStandUpBoard}>
@@ -70,7 +69,6 @@ export default function ActiveScrumBoardPage(): JSX.Element {
           <ScrumBoard projectId={projectId} sprint={activeSprint} standUp={todaysStandUp}/>
         </Space>
         {activeSprint && todaysStandUp ? (
-          // <div> style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}>
           <Space direction='vertical'>
             <Button onClick={handleViewScrumBoard}>
               View Active Scrum Board


### PR DESCRIPTION
<!-- Replace the #XX below with an issue number or the corresponding TROFOS ticket number-->

T3-60

<!-- Tag persons responsible for reviewing proposed changes -->

@thamruicong 

**Description**
Used antd library component to contain standup and scrum board so they won't overflow into each other in the carousel component

Works in mobile also:

https://github.com/user-attachments/assets/15935af2-b125-4ec0-a878-1a34ac82fbaf



<!-- Add a descriptive title below -->

**Other Information**

<!-- Add any other information below or remove this line completely -->

**Checklist**

- [X] My pull request has a descriptive title (not a vague title like `Update README.md`)

- [X] My pull request targets the `master` branch of the repository only

- [X] My commits follows these [commit message guidelines](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53)

- [ ] I added tests for the changes I made (if applicable)

- [ ] I added or updated documentation (if applicable)

- [ ] I have ran the project and its tests locally and verified that there are no visible errors

- [ ] Includes DB Migration
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
