### PR TITLE
Fix sprint completion bug

### DIFF
--- a/packages/backend/src/services/sprint.service.ts
+++ b/packages/backend/src/services/sprint.service.ts
@@ -217,7 +217,7 @@ async function updateSprintStatus(
   // upcoming is auto created, closed is handled automatically when new 'current' sprint is created
   if (status === 'current') {
     if (sprintToUpdateInstance.status !== 'upcoming' && sprintToUpdateInstance.status !== 'completed') {
-      throw new BadRequestError('Invalid status transition');
+      throw new BadRequestError('Invalid status transition: ' + sprintToUpdateInstance.status + ' -> ' + status);
     }
 
     return prisma.$transaction<Sprint>(async (tx: Prisma.TransactionClient) => {
@@ -261,7 +261,7 @@ async function updateSprintStatus(
   // publish event to generate retrospective insights
   else if (status === 'completed') {
     if (sprintToUpdateInstance.status !== 'current') {
-      throw new BadRequestError('Invalid status transition');
+      throw new BadRequestError('Invalid status transition: ' + sprintToUpdateInstance.status + ' -> ' + status);
     }
 
     return prisma.$transaction<Sprint>(async (tx: Prisma.TransactionClient) => {


### PR DESCRIPTION
<!-- Replace the #XX below with an issue number or the corresponding TROFOS ticket number-->

#XX

<!-- Tag persons responsible for reviewing proposed changes -->

@thamruicong 

**Description**

Attempt to fix issue where there are multiple 'completed' sprints. That bug that surfaced might have been due to a race condition- I'm not sure how to replicate. So I'll just try to make the update sprint more strict in state checking and 'auto-fix' wrong states

<!-- Add a descriptive title below -->

**Other Information**

<!-- Add any other information below or remove this line completely -->

**Checklist**

- [ ] My pull request has a descriptive title (not a vague title like `Update README.md`)

- [ ] My pull request targets the `master` branch of the repository only

- [ ] My commits follows these [commit message guidelines](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53)

- [ ] I added tests for the changes I made (if applicable)

- [ ] I added or updated documentation (if applicable)

- [ ] I have ran the project and its tests locally and verified that there are no visible errors

- [ ] Includes DB Migration
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
