### PR TITLE
feat: sso flag to enable/disable in .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ AI_DATABASE_URL="postgresql://admin:admin@postgres:5432/pgvector?schema=public"
 
 At project root:
 
-3. `docker compose -f .\docker-compose-production.yml --env-file ./.env.docker up`
+3. `docker compose -f ./docker-compose-production.yml --env-file ./.env.docker up`

--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -44,6 +44,7 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - AI_DATABASE_URL=${AI_DATABASE_URL}
       - REDIS_URL=${REDIS_URL}
+      - SSO_ENABLED=${SSO_ENABLED}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -49,6 +49,7 @@ services:
       - AI_DATABASE_URL=${E2E_AI_DATABASE_URL}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - REDIS_URL=${E2E_REDIS_URL}
+      - SSO_ENABLED=${SSO_ENABLED}
     links:
       - postgres
     networks:

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -56,6 +56,7 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - AI_DATABASE_URL=${AI_DATABASE_URL}
       - REDIS_URL=${REDIS_URL}
+      - SSO_ENABLED=${SSO_ENABLED}
     links:
       - postgres
     networks:

--- a/packages/backend/src/services/featureFlag.service.ts
+++ b/packages/backend/src/services/featureFlag.service.ts
@@ -2,6 +2,10 @@ import { Feature, FeatureFlag } from '@prisma/client';
 import prisma from '../models/prismaClient';
 
 const checkFeatureFlagActive = async (feature: Feature): Promise<Boolean> => {
+  if (feature === Feature.sso_login && process.env.SSO_ENABLED !== undefined) {
+    return process.env.SSO_ENABLED === 'true';
+  }
+
   const flag = await prisma.featureFlag.findUnique({
     where: { feature_name: feature },
     select: { active: true }
@@ -12,6 +16,14 @@ const checkFeatureFlagActive = async (feature: Feature): Promise<Boolean> => {
 
 const getAllFeatureFlags = async (): Promise<FeatureFlag[]> => {
   const featureFlags = await prisma.featureFlag.findMany();
+
+  if (process.env.SSO_ENABLED !== undefined) {
+    const ssoFlag = featureFlags.find((flag) => flag.feature_name === Feature.sso_login);
+    if (ssoFlag) {
+      ssoFlag.active = process.env.SSO_ENABLED === 'true';
+    }
+  }
+
   return featureFlags;
 }
 


### PR DESCRIPTION
N/A

@ganeshniyer

**Description**

Currently, there is no way to separate NUS SSO sign-in from TROFOS app, such that the package is an independent package and any other universities that may install it on their own servers.

**Other Information**

Placed a separate .env var that is prioritised over the database feature flag. Alternatives like adding a migration script to turn the feature flag off would also turn it off in the current project.

Quick setup guide: https://drive.google.com/drive/folders/1dwMT_xRd0MUPQtv0RLHeEfHlZmvFvyjg

**Checklist**

- [x] My pull request has a descriptive title (not a vague title like `Update README.md`)

- [x] My pull request targets the `master` branch of the repository only

- [x] My commits follows these [commit message guidelines](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53)

- [ ] I added tests for the changes I made (if applicable)

- [ ] I added or updated documentation (if applicable)

- [x] I have ran the project and its tests locally and verified that there are no visible errors

- [ ] Includes DB Migration
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
